### PR TITLE
Fix Windows compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mmap-fixed"
-version = "0.1.2"
+version = "0.1.3"
 authors = [
   "Khang <khang06@users.noreply.github.com>",
   "Elliott Linder <elliott@linder.bz>",
@@ -22,7 +22,7 @@ repository = "https://github.com/khang06/rust-mmap-fixed-fixed"
 libc = "0.2"
 
 [target."cfg(windows)".dependencies]
-winapi = { version = "0.3.9", features = ["memoryapi", "sysinfoapi", "handleapi"] }
+winapi = { version = "0.3.9", features = ["memoryapi", "sysinfoapi", "handleapi", "winerror"] }
 
 [dev-dependencies]
 tempdir = "0.3"


### PR DESCRIPTION
This PR solves windows compilation issues by adding the "winerror" feature to winapi

I also incremented the crate version number so that you can update directly the version on crates.io