### PR TITLE
Update to Rust 2018, port from winapi crate, fix crate package name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ fix for the Windows version. This exists only because there are no other
 alternative crates for `MAP_FIXED` allocations.
 """
 repository = "https://github.com/khang06/rust-mmap-fixed-fixed"
+edition = "2018"
 
 [target."cfg(unix)".dependencies]
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ edition = "2018"
 libc = "0.2"
 
 [target."cfg(windows)".dependencies]
-winapi = { version = "0.3.9", features = ["memoryapi", "sysinfoapi", "handleapi", "winerror"] }
+windows = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Memory", "Win32_System_SystemInformation", "Win32_Security"], default-features = false }
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "mmap-fixed"
+name = "mmap-fixed-fixed"
 version = "0.1.3"
 authors = [
   "Khang <khang06@users.noreply.github.com>",


### PR DESCRIPTION
I was trying to stop my library from compiling *two* different WinAPI-related crates. Here is a patch to:
* Update to 2018 edition, it didn't even have a set edition due to age probably
* Fix the crate name (it also makes it easier to use the Cargo patch/replace system)
* Port to the Windows crate which is better supported. Most of the code was simple to port. Tests and functionality still seems to work.